### PR TITLE
Cell with unit tests, styling, and interfaces

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,6 @@
 module.exports = function (grunt) {
-    var staticFiles = [ 'src/**/*.html' ];
+
+    var staticFiles = [ 'src/**/*.html', 'src/**/*.png' ];
 
     require('grunt-dojo2').initConfig(grunt, {
         copy: {
@@ -8,7 +9,32 @@ module.exports = function (grunt) {
                 cwd: '.',
                 src: staticFiles,
                 dest: '<%= devDirectory %>'
+            },
+            devStyles: {
+                expand: true,
+                cwd: '.',
+                src: 'src/styles/dgrid.css',
+                dest: '<%= devDirectory %>'
+            },
+            distStyles: {
+                expand: true,
+                cwd: '.',
+                src: 'src/styles/dgrid.css',
+                dest: '<%= distDirectory %>'
             }
         }
     });
+
+    grunt.registerTask('dev', grunt.config.get('devTasks').concat([
+        'copy:staticFiles',
+        'copy:staticTestFiles',
+        'postcss:modules-dev',
+        'copy:devStyles'
+    ]));
+
+    grunt.registerTask('dist', grunt.config.get('distTasks').concat([
+        'postcss:modules-dist',
+        'postcss:variables',
+        'copy:distStyles'
+    ]));
 };

--- a/src/Cell.ts
+++ b/src/Cell.ts
@@ -1,36 +1,25 @@
 import WidgetBase from '@dojo/widget-core/WidgetBase';
 import { RegistryMixin, RegistryMixinProperties }  from '@dojo/widget-core/mixins/Registry';
-import { v, w } from '@dojo/widget-core/d';
-import { HasValue, HasColumn, HasItem, HasCellRenderer, CellRendererProperties } from './interfaces';
+import { v } from '@dojo/widget-core/d';
+import { HasValue, HasColumn, HasItem } from './interfaces';
 import { theme, ThemeableMixin, ThemeableProperties } from '@dojo/widget-core/mixins/Themeable';
 
 import * as cellClasses from './styles/cell.css';
 
-export interface CellProperties extends ThemeableProperties, HasValue, HasColumn, HasItem, HasCellRenderer<any>, RegistryMixinProperties { }
+export interface CellProperties extends ThemeableProperties, HasValue, HasColumn, HasItem, RegistryMixinProperties { }
 
 @theme(cellClasses)
 class Cell extends ThemeableMixin(RegistryMixin(WidgetBase))<CellProperties> {
 	render() {
 		const {
-			value = '',
-			column,
-			item,
-			cellRenderer,
-			registry,
-			theme
+			value = ''
 		} = this.properties;
 
 		return v('td', {
 			role: 'gridcell',
 			classes: this.classes(cellClasses.cell)
 		}, [
-			cellRenderer ? w(cellRenderer(item), <CellRendererProperties> {
-				value,
-				column,
-				item,
-				registry,
-				theme
-			}) : String(value)
+			String(value)
 		]);
 	}
 }

--- a/src/Cell.ts
+++ b/src/Cell.ts
@@ -1,0 +1,38 @@
+import WidgetBase from '@dojo/widget-core/WidgetBase';
+import { RegistryMixin, RegistryMixinProperties }  from '@dojo/widget-core/mixins/Registry';
+import { v, w } from '@dojo/widget-core/d';
+import { HasValue, HasColumn, HasItem, HasCellRenderer, CellRendererProperties } from './interfaces';
+import { theme, ThemeableMixin, ThemeableProperties } from '@dojo/widget-core/mixins/Themeable';
+
+import * as cellClasses from './styles/cell.css';
+
+export interface CellProperties extends ThemeableProperties, HasValue, HasColumn, HasItem, HasCellRenderer<any>, RegistryMixinProperties { }
+
+@theme(cellClasses)
+class Cell extends ThemeableMixin(RegistryMixin(WidgetBase))<CellProperties> {
+	render() {
+		const {
+			value = '',
+			column,
+			item,
+			cellRenderer,
+			registry,
+			theme
+		} = this.properties;
+
+		return v('td', {
+			role: 'gridcell',
+			classes: this.classes(cellClasses.cell)
+		}, [
+			cellRenderer ? w(cellRenderer(item), <CellRendererProperties> {
+				value,
+				column,
+				item,
+				registry,
+				theme
+			}) : String(value)
+		]);
+	}
+}
+
+export default Cell;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,18 +1,9 @@
-import { WidgetBaseConstructor, WidgetProperties } from '@dojo/widget-core/interfaces';
-import { RegistryMixinProperties } from '@dojo/widget-core/mixins/Registry';
-
 export interface ItemProperties<T> {
 	id: string;
 	data: T;
 }
 
-export interface CellRendererProperties extends WidgetProperties, HasValue, HasColumn, HasItem, RegistryMixinProperties { }
-
-export interface HasCellRenderer<T> {
-	cellRenderer?(item: ItemProperties<T>): string | WidgetBaseConstructor<CellRendererProperties>;
-}
-
-export interface Column<T> extends HasCellRenderer<T> {
+export interface Column<T> {
 	id: string;
 	label?: string;
 	field?: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,32 @@
+import { WidgetBaseConstructor, WidgetProperties } from '@dojo/widget-core/interfaces';
+import { RegistryMixinProperties } from '@dojo/widget-core/mixins/Registry';
+
+export interface ItemProperties<T> {
+	id: string;
+	data: T;
+}
+
+export interface CellRendererProperties extends WidgetProperties, HasValue, HasColumn, HasItem, RegistryMixinProperties { }
+
+export interface HasCellRenderer<T> {
+	cellRenderer?(item: ItemProperties<T>): string | WidgetBaseConstructor<CellRendererProperties>;
+}
+
+export interface Column<T> extends HasCellRenderer<T> {
+	id: string;
+	label?: string;
+	field?: string;
+	sortable?: boolean; // default true
+}
+
+export interface HasColumn {
+	column: Column<any>;
+}
+
+export interface HasItem {
+	item: ItemProperties<any>;
+}
+
+export interface HasValue {
+	value: string;
+}

--- a/src/styles/cell.css
+++ b/src/styles/cell.css
@@ -1,0 +1,3 @@
+.cell {
+    composes: cell from './shared/cell.css';
+}

--- a/src/styles/cell.css.d.ts
+++ b/src/styles/cell.css.d.ts
@@ -1,0 +1,1 @@
+export const cell: string;

--- a/src/styles/dgrid.css
+++ b/src/styles/dgrid.css
@@ -1,0 +1,1 @@
+@import 'cell.css';

--- a/src/styles/dgrid.css.d.ts
+++ b/src/styles/dgrid.css.d.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/src/styles/shared/cell.css
+++ b/src/styles/shared/cell.css
@@ -1,0 +1,9 @@
+.cell {
+    padding: 3px;
+    text-align: left;
+    overflow: hidden;
+    vertical-align: top;
+    border: 1px solid #ddd;
+    border-top-style: none;
+    box-sizing: border-box;
+}

--- a/src/styles/shared/cell.css.d.ts
+++ b/src/styles/shared/cell.css.d.ts
@@ -1,0 +1,1 @@
+export const cell: string;

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -11,21 +11,21 @@ export const proxyUrl = 'http://localhost:9000/';
 // automatically
 export const capabilities = {
 	'browserstack.debug': false,
-	project: 'Dojo 2',
-	name: 'dojo/dgrid'
+	project: '@dojo/dgrid',
+	name: '@dojo/dgrid'
 };
 
 // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
 // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
 // capabilities options specified for an environment will be copied as-is
 export const environments = [
-	{ browserName: 'internet explorer', version: [ '10', '11' ], platform: 'WINDOWS' },
-	{ browserName: 'firefox', platform: 'WINDOWS' },
-	{ browserName: 'chrome', platform: 'WINDOWS' }
+	{ browserName: 'Edge', platform: 'Windows' },
+	{ browserName: 'Firefox', platform: 'Windows' },
+	{ browserName: 'Chrome', platform: 'Windows' }
 ];
 
 // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
-export const maxConcurrency = 2;
+export const maxConcurrency = 1;
 
 // Name of the tunnel class to use for WebDriver tests
 export const tunnel = 'BrowserStackTunnel';
@@ -52,8 +52,11 @@ export const loaderOptions = {
 	packages: [
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
-		{ name: 'dojo', location: 'node_modules/intern/node_modules/dojo' },
-		{ name: '@dojo', location: 'node_modules/intern/node_modules/@dojo' }
+		{ name: 'chai', location: 'node_modules/chai', main: 'chai' },
+		{ name: 'dojo', location: 'node_modules/intern/browser_modules/dojo' },
+		{ name: '@dojo', location: 'node_modules/@dojo' },
+		{ name: 'maquette', location: 'node_modules/maquette/dist', main: 'maquette' },
+		{ name: 'sinon', location: 'node_modules/sinon/pkg', main: 'sinon' }
 	]
 };
 
@@ -64,4 +67,4 @@ export const suites = [ 'tests/unit/all' ];
 export const functionalSuites = [ 'tests/functional/all' ];
 
 // A regular expression matching URLs to files that should not be included in code coverage analysis
-export const excludeInstrumentation = /(?:node_modules|bower_components|tests)[\/\\]/;
+export const excludeInstrumentation = /(?:node_modules|bower_components|tests|examples)[\/\\]/;

--- a/tests/unit/Cell.ts
+++ b/tests/unit/Cell.ts
@@ -2,8 +2,6 @@ import * as registerSuite from 'intern/lib/interfaces/object';
 import { assert } from 'chai';
 import { VNode } from '@dojo/interfaces/vdom';
 import Cell from '../../src/Cell';
-import { ItemProperties, CellRendererProperties } from '../../src/interfaces';
-import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 
 registerSuite({
 	name: 'Cell',
@@ -15,21 +13,6 @@ registerSuite({
 			const vnode = <VNode> cell.__render__();
 			assert.strictEqual(vnode.vnodeSelector, 'td');
 			assert.strictEqual(vnode.text, 'Hello, World!');
-		},
-		'data property value passed through to renderer when provided'() {
-			const cellRenderer = (item: ItemProperties<any>) => {
-				return class extends WidgetBase<CellRendererProperties> {
-					render() {
-						return this.properties.value.replace('World', 'Dojo');
-					}
-				};
-			};
-			const cell = new Cell();
-			cell.setProperties(<any> { value: 'Hello, World!', cellRenderer });
-
-			const vnode = <VNode> cell.__render__();
-			assert.strictEqual(vnode.vnodeSelector, 'td');
-			assert.strictEqual(vnode.text, 'Hello, Dojo!');
 		},
 		'null is returned when no data property'() {
 			const cell = new Cell();

--- a/tests/unit/Cell.ts
+++ b/tests/unit/Cell.ts
@@ -1,0 +1,50 @@
+import * as registerSuite from 'intern/lib/interfaces/object';
+import { assert } from 'chai';
+import { VNode } from '@dojo/interfaces/vdom';
+import Cell from '../../src/Cell';
+import { ItemProperties, CellRendererProperties } from '../../src/interfaces';
+import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+
+registerSuite({
+	name: 'Cell',
+	render: {
+		'data property used as cell text node'() {
+			const cell = new Cell();
+			cell.setProperties(<any> { value: 'Hello, World!' });
+
+			const vnode = <VNode> cell.__render__();
+			assert.strictEqual(vnode.vnodeSelector, 'td');
+			assert.strictEqual(vnode.text, 'Hello, World!');
+		},
+		'data property value passed through to renderer when provided'() {
+			const cellRenderer = (item: ItemProperties<any>) => {
+				return class extends WidgetBase<CellRendererProperties> {
+					render() {
+						return this.properties.value.replace('World', 'Dojo');
+					}
+				};
+			};
+			const cell = new Cell();
+			cell.setProperties(<any> { value: 'Hello, World!', cellRenderer });
+
+			const vnode = <VNode> cell.__render__();
+			assert.strictEqual(vnode.vnodeSelector, 'td');
+			assert.strictEqual(vnode.text, 'Hello, Dojo!');
+		},
+		'null is returned when no data property'() {
+			const cell = new Cell();
+
+			const vnode = <VNode> cell.__render__();
+			assert.strictEqual(vnode.vnodeSelector, 'td');
+			assert.isUndefined(vnode.text);
+		},
+		'cell data is stringified'() {
+			const cell = new Cell();
+			cell.setProperties(<any> { value: <any> 1234 });
+
+			const vnode = <VNode> cell.__render__();
+			assert.strictEqual(vnode.vnodeSelector, 'td');
+			assert.strictEqual(vnode.text, '1234');
+		}
+	}
+});

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,1 +1,1 @@
-import './main';
+import './Cell';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds the Cell widget with styling and unit tests. Adds interfaces used by the Cell properties.

Supports an optional `cellRenderer` that is passed an item and can return either a widget constructor or the name of a registered widget constructor.