### PR TITLE
Add examples folder and HTML page

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,6 +12,12 @@ module.exports = function (grunt) {
                 cwd: 'src',
                 src: 'styles/dgrid.css',
                 dest: '<%= distDirectory %>'
+            },
+            examples: {
+                expand: true,
+                cwd: '.',
+                src: 'examples/**/*.{html,css,json,xml,js,txt}',
+                dest: '<%= devDirectory %>'
             }
         }
     });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,8 @@ module.exports = function (grunt) {
 
     grunt.registerTask('dev', grunt.config.get('devTasks').concat([
         'postcss:modules-dev',
-        'copy:devStyles'
+        'copy:devStyles',
+        'copy:examples'
     ]));
 
     grunt.registerTask('dist', grunt.config.get('distTasks').concat([

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html>
+<head>
+	<title>dgrid test page</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="stylesheet" href="../src/styles/dgrid.css">
+	<style>
+		body {
+			font-family: Myriad, Tahoma, Helvetica, Arial, sans-serif;
+		}
+	</style>
+</head>
+
+<body>
+	<ul id="links">
+		<li><a href="?module=pagination">Pagination</a></li>
+	</ul>
+
+	<script src="../../node_modules/@dojo/loader/loader.min.js"></script>
+
+	<script>
+		require.config({
+			baseUrl: '..',
+			packages: [
+				{ name: 'tests', location: 'tests' },
+				{ name: 'dgrid', location: 'src' },
+				{ name: 'examples', location: 'examples' },
+				{ name: '@dojo', location: '../node_modules/@dojo' },
+				{ name: 'pepjs', location: '../node_modules/pepjs/dist', main: 'pep' },
+				{ name: 'maquette', location: '../node_modules/maquette/dist', main: 'maquette' }
+			]
+		});
+
+		(function () {
+			var query = window.location.search.substring(1).split('&');
+			var module;
+			var pair;
+			var i;
+
+			for (i = 0; i < query.length; i++) {
+				pair = query[i].split('=');
+
+				if (pair[0].toLowerCase() === 'module') {
+					module = pair[1].toLowerCase();
+					break;
+				}
+			}
+
+			if (module) {
+				document.getElementById('links').remove();
+				require([ 'examples/' + module ], function () {});
+			}
+		})();
+	</script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -13,7 +13,7 @@
 
 <body>
 	<ul id="links">
-		<li><a href="?module=pagination">Pagination</a></li>
+		<!-- <li><a href="?module=pagination">Pagination</a></li> -->
 	</ul>
 
 	<script src="../../node_modules/@dojo/loader/loader.min.js"></script>


### PR DESCRIPTION
The `examples/index.html` page can be used for all examples.

To create an example page:
* create a TypeScript file in the `examples` folder that creates a projector and appends it to the document.
* add a link to it in `ul#links` in `index.html`

Run `grunt dev` and open `_build/examples/index.html` in your browser. You should see a list of links to test pages.
