### PR TITLE
Switch to BrowserStack for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,19 @@ env:
   global:
   - SAUCE_USERNAME: dojo2-ts-ci
   - SAUCE_ACCESS_KEY: e92610e3-834e-4bec-a3b5-6f7b9d874601
+  - BROWSERSTACK_USERNAME: dylanschiemann2
+  - BROWSERSTACK_ACCESS_KEY: 2upt88qsxsqqeukQvecu
+before_install:
+- if [ ${TRAVIS_BRANCH-""} == "master" ] && [ -n ${encrypted_12c8071d2874_key-""}
+  ]; then openssl aes-256-cbc -K $encrypted_12c8071d2874_key -iv $encrypted_12c8071d2874_iv
+  -in deploy_key.enc -out deploy_key -d; fi
 install:
 - travis_retry npm install grunt-cli
 - travis_retry npm install
 script:
 - grunt
 - grunt intern:node --combined
-- grunt intern:saucelabs --combined
+- grunt intern:browserstack --combined
 - grunt remapIstanbul:ci
 - grunt uploadCoverage
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ env:
   - SAUCE_ACCESS_KEY: e92610e3-834e-4bec-a3b5-6f7b9d874601
   - BROWSERSTACK_USERNAME: dylanschiemann2
   - BROWSERSTACK_ACCESS_KEY: 2upt88qsxsqqeukQvecu
-before_install:
-- if [ ${TRAVIS_BRANCH-""} == "master" ] && [ -n ${encrypted_12c8071d2874_key-""}
-  ]; then openssl aes-256-cbc -K $encrypted_12c8071d2874_key -iv $encrypted_12c8071d2874_iv
-  -in deploy_key.enc -out deploy_key -d; fi
 install:
 - travis_retry npm install grunt-cli
 - travis_retry npm install

--- a/tests/intern-local.ts
+++ b/tests/intern-local.ts
@@ -1,6 +1,6 @@
 export * from './intern';
 
-export const tunnel = 'NullTunnel';
+export const tunnel = 'SeleniumTunnel';
 export const tunnelOptions = {
 	hostname: 'localhost',
 	port: '4444'

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -23,7 +23,7 @@ export const environments = [
 	{ browserName: 'edge' },
 	{ browserName: 'firefox', platform: 'WINDOWS' },
 	{ browserName: 'chrome', platform: 'WINDOWS' },
-	{ browserName: 'safari', version: '10', platform: 'MAC' },
+	{ browserName: 'safari', version: '9.1', platform: 'MAC' },
 	{ browserName: 'iPhone', version: '9.1' }
 ];
 

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -19,13 +19,16 @@ export const capabilities = {
 // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
 // capabilities options specified for an environment will be copied as-is
 export const environments = [
-	{ browserName: 'Edge', platform: 'Windows' },
-	{ browserName: 'Firefox', platform: 'Windows' },
-	{ browserName: 'Chrome', platform: 'Windows' }
+	{ browserName: 'internet explorer', version: '11' },
+	{ browserName: 'edge' },
+	{ browserName: 'firefox', platform: 'WINDOWS' },
+	{ browserName: 'chrome', platform: 'WINDOWS' },
+	{ browserName: 'safari', version: '10', platform: 'MAC' },
+	{ browserName: 'iPhone', version: '9.1' }
 ];
 
 // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
-export const maxConcurrency = 1;
+export const maxConcurrency = 5;
 
 // Name of the tunnel class to use for WebDriver tests
 export const tunnel = 'BrowserStackTunnel';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Switches to BrowserStack JS Foundation team for CI testing with Travis.

This replaces #35