### PR TITLE
On Demand Scrolling

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -14,6 +14,7 @@
 <body>
 	<ul id="links">
 		<li><a href="?module=simple_grid">Simple Grid</a></li>
+		<li><a href="?module=large_grid">Large Grid</a></li>
 	</ul>
 
 	<script src="../../node_modules/@dojo/loader/loader.min.js"></script>

--- a/examples/large_grid.ts
+++ b/examples/large_grid.ts
@@ -1,0 +1,60 @@
+import { w } from '@dojo/widget-core/d';
+import { WidgetProperties } from '@dojo/widget-core/interfaces';
+import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
+import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+import Grid from '../src/Grid';
+import ArrayDataProvider from '../src/providers/ArrayDataProvider';
+
+const data = [
+	{ order: 1, name: 'preheat', description: 'Preheat your oven to 350F' },
+	{ order: 2, name: 'mix dry', description: 'In a medium bowl, combine flour, salt, and baking soda' },
+	{ order: 3, name: 'mix butter', description: 'In a large bowl, beat butter, then add the brown sugar and white sugar then mix' },
+	{ order: 4, name: 'mix together', description: 'Slowly add the dry ingredients from the medium bowl to the wet ingredients in the large bowl, mixing until the dry ingredients are totally combined' },
+	{ order: 5, name: 'chocolate chips', description: 'Add chocolate chips' },
+	{ order: 6, name: 'make balls', description: 'Scoop up a golf ball size amount of dough with a spoon and drop in onto a cookie sheet' },
+	{ order: 7, name: 'bake', description: 'Put the cookies in the oven and bake for about 10-14 minutes' },
+	{ order: 8, name: 'remove', description: 'Using a spatula, lift cookies off onto wax paper or a cooling rack' },
+	{ order: 9, name: 'eat', description: 'Eat and enjoy!' }
+];
+
+const instructions: any[] = [];
+for (let i = 1; i <= 1000; i++) {
+	const instruction = Object.create(data[Math.floor(Math.random() * data.length)]);
+	instruction.order = i;
+	instructions.push(instruction);
+}
+
+const dataProvider = new ArrayDataProvider({
+	idProperty: 'order',
+	data: instructions
+});
+
+const columns = [
+	{
+		id: 'order',
+		label: 'step' // give column a custom name
+	},
+	{
+		id: 'name'
+	},
+	{
+		id: 'description',
+		label: 'what to do',
+		sortable: false
+	}
+];
+
+const ProjectorBase = ProjectorMixin(WidgetBase);
+
+class Projector extends ProjectorBase<WidgetProperties> {
+	render() {
+		return w(Grid, {
+			dataProvider,
+			columns
+		});
+	}
+}
+
+const projector = new Projector();
+
+projector.append();

--- a/src/Body.ts
+++ b/src/Body.ts
@@ -1,30 +1,41 @@
+import { from, includes } from '@dojo/shim/array';
 import Map from '@dojo/shim/Map';
 import { v, w } from '@dojo/widget-core/d';
+import { DNode, PropertiesChangeEvent } from '@dojo/widget-core/interfaces';
 import { RegistryMixin, RegistryMixinProperties } from '@dojo/widget-core/mixins/Registry';
 import { theme, ThemeableMixin, ThemeableProperties } from '@dojo/widget-core/mixins/Themeable';
-import WidgetBase from '@dojo/widget-core/WidgetBase';
-import { HasColumns, HasItems, HasScrollTo, ItemProperties } from './interfaces';
+import WidgetBase, { onPropertiesChanged } from '@dojo/widget-core/WidgetBase';
+import { HasBufferRows, HasColumns, HasItems, HasScrollTo, HasSize, HasSlice, HasSliceEvent, ItemProperties } from './interfaces';
 import Row from './Row';
 
 import * as bodyClasses from './styles/body.m.css';
 
 export const BodyBase = ThemeableMixin(RegistryMixin(WidgetBase));
 
-export interface BodyProperties extends ThemeableProperties, HasColumns, HasItems, HasScrollTo, RegistryMixinProperties { }
+export interface BodyProperties extends ThemeableProperties, HasBufferRows, HasColumns, HasItems, HasScrollTo, HasSize, HasSlice, HasSliceEvent, RegistryMixinProperties {}
 
 interface RenderedDetails {
 	add: boolean;
-	delete: boolean;
+	remove: boolean;
 	element?: HTMLElement;
 	index: number;
 	height?: number;
-};
+}
 
 @theme(bodyClasses)
 class Body extends BodyBase<BodyProperties> {
-	private _itemElementMap = new Map<string, RenderedDetails>;
+	private _firstVisibleKey: string;
+	private _itemElementMap = new Map<string, RenderedDetails>();
+	private _marginTop?: RenderedDetails;
+	private _scrollerElement: HTMLElement;
+	private _scrollTop = 0;
 
-	createNodeFromItem(item: ItemProperties, index: number) {
+	/**
+	 * Creates a DNode for the passed item and either
+	 * creates or updates an associated entry in
+	 * the item element map.
+	 */
+	protected createNodeFromItem(item: ItemProperties, index: number) {
 		const {
 			_itemElementMap: itemElementMap,
 			properties: {
@@ -39,7 +50,7 @@ class Body extends BodyBase<BodyProperties> {
 		if (!details) {
 			details = {
 				add: true,
-				delete: false,
+				remove: false,
 				index: index
 			};
 			itemElementMap.set(key, details);
@@ -49,9 +60,7 @@ class Body extends BodyBase<BodyProperties> {
 		}
 
 		return v('div', {
-			key,
-			role: 'row',
-			classes: this.classes(bodyClasses.row)
+			key
 		}, [
 			w<Row>('row', {
 				columns,
@@ -63,10 +72,95 @@ class Body extends BodyBase<BodyProperties> {
 		]);
 	}
 
-	protected onElementChange(element: HTMLElement, key: string): void {
+	/**
+	 * Uses the height of the scroll area and the estimated row height
+	 * to estimate the number of rows that will fill it
+	 */
+	protected estimatedRowCount(): number {
+		const {
+			_scrollerElement: scrollerElement
+		} = this;
+
+		const height = scrollerElement.offsetHeight;
+		if (height) {
+			return Math.round(height / this.estimatedRowHeight());
+		}
+		return 30;
+	}
+
+	/**
+	 * Based on what is currently rendered, find the average height
+	 * of each row and, if nothing is rendered, return 20.
+	 */
+	protected estimatedRowHeight(): number {
 		const {
 			_itemElementMap: itemElementMap
 		} = this;
+
+		let rowHeight = 0;
+		let rowCount = 0;
+		for (let details of from(itemElementMap.values())) {
+			if (details.element) {
+				rowHeight += details.element.offsetHeight;
+				rowCount++;
+			}
+		}
+
+		return Math.round(rowHeight / rowCount) || 20;
+	}
+
+	/**
+	 * Shared method used by both onElementCreated and
+	 * onElementUpdated to track DOM changes
+	 */
+	protected onElementChange(element: HTMLElement, key: string): void {
+		const {
+			_itemElementMap: itemElementMap,
+			_marginTop: marginTop
+		} = this;
+
+		if (key === 'marginTop') {
+			marginTop && (marginTop.element = element);
+			return;
+		}
+
+		if (key === 'marginBottom') {
+			return;
+		}
+
+		if (key === 'scroller') {
+			this._scrollerElement = element;
+
+			const {
+				properties: {
+					items,
+					slice: {
+						start = 0
+					} = {},
+					onSliceRequest
+				}
+			} = this;
+
+			if (items.length === 0) {
+				// If there has been no data passed (e.g. during initialization),
+				// we wait until the scroll area appears to get a more accurate
+				// estimate of how many rows to ask for initially
+
+				// Use the start value we found and request an amount of data
+				// equal to the additional data above the scroll area, the number
+				// of visible rows and the additional data below the scroll area
+				onSliceRequest && onSliceRequest({ start, count: this.estimatedRowCount() });
+			}
+			else {
+				// We hit this when the children of the scroll area change
+				// e.g. after we guess how many rows we'll need. The onScroll
+				// method will take this information and add additional rows
+				// before and after this content as padding.
+				this.onScroll();
+			}
+
+			return;
+		}
 
 		const details = itemElementMap.get(key);
 		if (details) {
@@ -80,35 +174,417 @@ class Body extends BodyBase<BodyProperties> {
 	}
 
 	protected onElementUpdated(element: HTMLElement, key: string): void {
+		if (key === 'scroller') {
+			const {
+				_firstVisibleKey: firstVisibleKey,
+				_itemElementMap: itemElementMap,
+				_marginTop: marginTop,
+				_scrollerElement: scrollerElement,
+				properties: {
+					onScrollToComplete,
+					scrollTo
+				}
+			} = this;
+			let scrollTop = this._scrollTop;
+
+			const detailsEntries = from(itemElementMap.entries());
+
+			// Check to see if all items are new
+			let cleared = true;
+			for (const [ , details] of detailsEntries) {
+				if (!details.add) {
+					cleared = false;
+					break;
+				}
+			}
+			if (cleared) {
+				scrollTop = 0;
+				if (marginTop && marginTop.element) {
+					scrollTop = marginTop.element.offsetHeight;
+				}
+
+				if (onScrollToComplete && scrollTo) {
+					onScrollToComplete(scrollTo);
+				}
+
+				// mark nodes as having been factored into scroll calculations
+				for (const [ , details] of detailsEntries) {
+					details.add = false;
+				}
+				marginTop && (marginTop.add = false);
+			}
+			else {
+				// Track size changed of rows before the first visible row
+				let beforeVisible = true;
+				for (const [ itemKey, details ] of detailsEntries) {
+					if (itemKey === firstVisibleKey) {
+						beforeVisible = false;
+					}
+
+					if (beforeVisible) {
+						if (details.add && details.element) {
+							// added items increase scrollTop
+							scrollTop += details.element.offsetHeight;
+						}
+						if (details.remove) {
+							// removed items decrease scrollTop
+							scrollTop -= (details.height || 0);
+						}
+					}
+
+					// mark nodes as having been factored into scroll calculations
+					details.add = false;
+					if (details.remove) {
+						itemElementMap.delete(itemKey);
+					}
+				}
+
+				// factor in the addition or removal of the top margin
+				if (marginTop) {
+					if (marginTop.add && marginTop.element) {
+						scrollTop += marginTop.element.offsetHeight;
+						marginTop.add = false;
+					}
+					if (marginTop.remove) {
+						scrollTop -= (marginTop.height || 0);
+						delete this._marginTop;
+					}
+				}
+			}
+
+			if (scrollerElement.scrollTop !== scrollTop) {
+				// The scroll event handler will adjust the slice
+				scrollerElement.scrollTop = scrollTop;
+				return;
+			}
+			// Otherwise, let the onElementChange method handle the slice
+		}
+
 		this.onElementChange(element, key);
 	}
 
-	render() {
+	@onPropertiesChanged()
+	onPropertiesChanged(evt: PropertiesChangeEvent<this, BodyProperties>) {
 		const {
-			columns,
-			items,
-			registry,
-			theme
-		} = this.properties;
+			scrollTo
+		} = evt.properties;
+		const {
+			_itemElementMap: itemElementMap,
+			_scrollerElement: scrollerElement,
+			properties: {
+				items,
+				onScrollToComplete,
+				onSliceRequest
+			}
+		} = this;
+
+		if (includes(evt.changedPropertyKeys, 'scrollTo') && scrollTo) {
+			// the scrollTo property was passed either by the user
+			// or by the grid after a call to onScrollToRequest
+			const index = scrollTo.index;
+			for (const item of items) {
+				// we saved the "true" index on all details
+				// objects so we can just directly compare
+				if (item.index === index) {
+					const renderedDetails = itemElementMap.get(item.id);
+					if (renderedDetails && renderedDetails.element) {
+						// if this exists within the grid, just scroll to it
+						// and allow the event handler to fill in any missing data
+						scrollerElement.scrollTop = renderedDetails.element.offsetTop;
+						// notify the property listener that this is done
+						// to allow it to clear this property
+						onScrollToComplete && onScrollToComplete(scrollTo);
+						return;
+					}
+					break;
+				}
+			}
+
+			// this index is not currently rendered so we request a slice
+			// of the data with a number of rows to hopefully fill in the scroll area
+			onSliceRequest && onSliceRequest({ start: index, count: this.estimatedRowCount() });
+		}
+	}
+
+	protected onScroll() {
+		const {
+			_itemElementMap: itemElementMap,
+			_scrollerElement: scrollerElement,
+			properties: {
+				bufferRows = 10,
+				items,
+				rowDrift = 5,
+				slice: {
+					start = 0
+				} = {},
+				size: {
+					dataLength
+				},
+				onScrollToRequest,
+				onSliceRequest
+			}
+		} = this;
+		const max = (dataLength > 0 ? dataLength - 1 : 0);
+		const visibleKeys = this.visibleKeys();
+
+		// On a very rapid scroll, the grid may have reached
+		// an area with no rendered rows
+		if (visibleKeys.length === 0) {
+			const scroll = scrollerElement.scrollTop;
+			const allDetails = from(itemElementMap.values());
+			for (const details of allDetails) {
+				if (details.element && details.element.offsetTop) {
+					const delta = (details.element.offsetTop - scroll);
+					if (delta > 0) {
+						// The top of the rendered data is below the current viewport
+						// so we try to guess how many rows were skipped and jump
+						// down to that area
+						const estimatedRowHeight = this.estimatedRowHeight();
+						const index = Math.max(0, (start - Math.round(delta / estimatedRowHeight)));
+						onScrollToRequest && onScrollToRequest({ index });
+						return;
+					}
+					break;
+				}
+			}
+			for (const renderedDetails of allDetails.reverse()) {
+				if (renderedDetails.element && renderedDetails.element.offsetTop && renderedDetails.element.offsetHeight) {
+					const delta = (scroll - (renderedDetails.element.offsetTop + renderedDetails.element.offsetHeight));
+					if (delta > 0) {
+						// The bottom of the rendered data is above the current viewport
+						// so we try to guess how many rows were skipped and jump
+						// down to that area
+						const estimatedRowHeight = this.estimatedRowHeight();
+						const index = Math.min(max, (start + items.length + Math.round(delta / estimatedRowHeight)));
+						onScrollToRequest && onScrollToRequest({ index });
+						return;
+					}
+					break;
+				}
+			}
+		}
+		else {
+			// This is the typical path the code will take
+			this._scrollTop = scrollerElement.scrollTop;
+			this._firstVisibleKey = visibleKeys[0];
+			const details = itemElementMap.get(this._firstVisibleKey);
+			if (details) {
+				// Use the index of the first row as a starting point
+				// as well as moving back a few rows so there's
+				// additional data above the scroll area
+				const sliceStart = Math.max(0, details.index - bufferRows);
+				let sliceCount = (Math.min(details.index, bufferRows) + visibleKeys.length + bufferRows);
+				// Use the start value we found and request an amount of data
+				// equal to the additional data above the scroll area, the number
+				// of visible rows and the additional data below the scroll area
+
+				// Limit data requests so that we only ever ask for
+				// a. start/count combinations that differ from what we already have (see c.)
+				// b. a start or end index change that exceeds a limit we're comfortable with
+				// c. the very start or very end of the data even if that limit is not reached
+				const startDelta = Math.abs(sliceStart - start);
+				const countDelta = Math.abs(sliceCount - items.length);
+				const atStart = (sliceStart === 0);
+				const atEnd = (sliceStart + sliceCount) === max;
+				if ((startDelta || countDelta) && (atStart || atEnd || startDelta > rowDrift || countDelta > rowDrift)) {
+					onSliceRequest && onSliceRequest({ start: sliceStart, count: sliceCount });
+				}
+			}
+		}
+	}
+
+	render(): DNode {
+		const {
+			_itemElementMap: itemElementMap,
+			properties: {
+				items,
+				size: {
+					dataLength
+				},
+				slice: {
+					start = 0
+				} = {}
+			}
+		} = this;
+		const max = (dataLength > 0 ? dataLength - 1 : 0);
+
+		const children: DNode[] = [];
+
+		// Create a top margin if the data has any offset at all
+		let marginTop = this._marginTop;
+		if (start > 0) {
+			if (!marginTop) {
+				marginTop = this._marginTop = {
+					add: true,
+					remove: false,
+					index: -1
+				};
+			}
+			children.push(v('div', {
+				key: 'marginTop',
+				styles: {
+					height: '10000px'
+				}
+			}));
+		}
+		else if (marginTop) {
+			if (marginTop.element) {
+				marginTop.height = marginTop.element.offsetHeight;
+			}
+			marginTop.remove = true;
+		}
+
+		const previousKeys = from(itemElementMap.keys());
+		if (previousKeys.length === 0) {
+			// There were no item rows the last time render was called
+			// so every row is added
+			for (let i = 0, item; (item = items[i]); i++) {
+				children.push(this.createNodeFromItem(item, (start + i)));
+			}
+		}
+		else {
+			// Create a new map so that the items will be ordered correctly
+			const updatedElementMap = new Map<string, RenderedDetails>();
+
+			// Keep a map of current keys (item IDs) and items
+			const itemsByKey: { [key: string]: DNode } = {};
+			const currentKeys: string[] = items.map((item, index) => {
+				const key = item.id;
+				// createNodeFromItem marks this item as having been added
+				// automatically if it didn't exist in the mapping (is new)
+				itemsByKey[key] = this.createNodeFromItem(item, (start + index));
+				return key;
+			});
+
+			// find which keys are new and at what index they will appear
+			let cleared = true;
+			let addedKeys: string[] = [];
+			const keyPatches: { [ index: number]: string[] } = {};
+			let previousKeyIndex = 0;
+			for (const currentKey of currentKeys) {
+				const foundAtIndex = previousKeys.indexOf(currentKey, previousKeyIndex);
+				if (foundAtIndex === -1) {
+					addedKeys.push(currentKey);
+				}
+				else {
+					if (addedKeys.length) {
+						keyPatches[previousKeyIndex] = addedKeys;
+						addedKeys = [];
+					}
+
+					cleared = false;
+					previousKeyIndex = (foundAtIndex + 1);
+				}
+			}
+			if (addedKeys.length) {
+				keyPatches[previousKeys.length] = addedKeys;
+			}
+
+			// If all keys are new, we can start from scratch
+			if (cleared) {
+				itemElementMap.clear();
+				return this.render();
+			}
+
+			// Use previous keys to watch for deleted items
+			// and insert new keys at the indexes detected above
+			for (let i = 0, il = previousKeys.length; i <= il; i++) {
+				const key = previousKeys[i];
+
+				const keyPatch = keyPatches[i];
+				if (keyPatch) {
+					for (const addedKey of keyPatch) {
+						// Insert any newly introduced items
+						// that were added at this index
+						children.push(itemsByKey[addedKey]);
+
+						// Add to the updated element map
+						const update = itemElementMap.get(addedKey);
+						if (update) {
+							updatedElementMap.set(addedKey, update);
+						}
+					}
+				}
+
+				if (i < il) {
+					const item = itemsByKey[key];
+					const details = itemElementMap.get(key);
+					if (item) {
+						// This item has neither been added nor removed
+						// since the last render
+						children.push(item);
+
+						// Add to the updated element map
+						const update = itemElementMap.get(key);
+						if (update) {
+							updatedElementMap.set(key, update);
+						}
+					}
+					else if (details) {
+						// This item was deleted since the last render
+						if (!details.remove && details.element) {
+							// Store its rendered height before it is removed from DOM
+							// as it will not be added as a row in the next render
+							details.height = details.element.offsetHeight;
+						}
+						// Mark this item as having been deleted
+						details.remove = true;
+
+						// Add to the updated element map.
+						// This entry will be deleted once its size
+						// is taken into account in onElementUpdated
+						const updated = itemElementMap.get(key);
+						if (updated) {
+							updatedElementMap.set(key, updated);
+						}
+					}
+				}
+			}
+
+			// Store the updated item map
+			this._itemElementMap = updatedElementMap;
+		}
+
+		// Create a bottom margin if the data doesn't extend all the way to the end
+		if (start + items.length < max) {
+			children.push(v('div', {
+				key: 'marginBottom',
+				styles: {
+					height: ('10000px')
+				}
+			}));
+		}
 
 		return v('div', {
-				classes: this.classes(bodyClasses.scroller)
-			},
-			[
-				v('div', {
-					classes: this.classes(bodyClasses.content)
-				},
-				items.map((item) => {
-					return w<Row>('row', {
-						columns,
-						item,
-						key: item.id,
-						registry,
-						theme
-					});
-				}))
-			]
-		);
+			classes: this.classes(bodyClasses.scroller),
+			key: 'scroller',
+			onscroll: this.onScroll
+		}, children);
+	}
+
+	protected visibleKeys() {
+		const {
+			_itemElementMap: itemElementMap,
+			_scrollerElement: scrollerElement
+		} = this;
+
+		const scrollTop = scrollerElement.scrollTop;
+		const contentHeight = scrollerElement.offsetHeight;
+		const visible: string[] = [];
+		for (const [ key, details ] of from(itemElementMap.entries())) {
+			const element = details.element;
+			if (element) {
+				const top = element.offsetTop;
+				const height = element.offsetHeight;
+				if ((top + height) >= scrollTop && top < (scrollTop + contentHeight)) {
+					visible.push(key);
+				}
+				else if (visible.length) {
+					break;
+				}
+			}
+		}
+		return visible;
 	}
 }
 

--- a/src/Body.ts
+++ b/src/Body.ts
@@ -1,8 +1,9 @@
+import Map from '@dojo/shim/Map';
 import { v, w } from '@dojo/widget-core/d';
 import { RegistryMixin, RegistryMixinProperties } from '@dojo/widget-core/mixins/Registry';
 import { theme, ThemeableMixin, ThemeableProperties } from '@dojo/widget-core/mixins/Themeable';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
-import { HasColumns, HasItems, HasScrollTo } from './interfaces';
+import { HasColumns, HasItems, HasScrollTo, ItemProperties } from './interfaces';
 import Row from './Row';
 
 import * as bodyClasses from './styles/body.m.css';
@@ -11,8 +12,77 @@ export const BodyBase = ThemeableMixin(RegistryMixin(WidgetBase));
 
 export interface BodyProperties extends ThemeableProperties, HasColumns, HasItems, HasScrollTo, RegistryMixinProperties { }
 
+interface RenderedDetails {
+	add: boolean;
+	delete: boolean;
+	element?: HTMLElement;
+	index: number;
+	height?: number;
+};
+
 @theme(bodyClasses)
 class Body extends BodyBase<BodyProperties> {
+	private _itemElementMap = new Map<string, RenderedDetails>;
+
+	createNodeFromItem(item: ItemProperties, index: number) {
+		const {
+			_itemElementMap: itemElementMap,
+			properties: {
+				columns,
+				theme,
+				registry
+			}
+		} = this;
+
+		const key = item.id;
+		let details = itemElementMap.get(key);
+		if (!details) {
+			details = {
+				add: true,
+				delete: false,
+				index: index
+			};
+			itemElementMap.set(key, details);
+		}
+		else {
+			details.index = index;
+		}
+
+		return v('div', {
+			key,
+			role: 'row',
+			classes: this.classes(bodyClasses.row)
+		}, [
+			w<Row>('row', {
+				columns,
+				item,
+				key,
+				registry,
+				theme
+			})
+		]);
+	}
+
+	protected onElementChange(element: HTMLElement, key: string): void {
+		const {
+			_itemElementMap: itemElementMap
+		} = this;
+
+		const details = itemElementMap.get(key);
+		if (details) {
+			// store the DOM node if its representation changes
+			details.element = element;
+		}
+	}
+
+	protected onElementCreated(element: HTMLElement, key: string): void {
+		this.onElementChange(element, key);
+	}
+
+	protected onElementUpdated(element: HTMLElement, key: string): void {
+		this.onElementChange(element, key);
+	}
+
 	render() {
 		const {
 			columns,

--- a/src/Body.ts
+++ b/src/Body.ts
@@ -2,14 +2,14 @@ import { v, w } from '@dojo/widget-core/d';
 import { RegistryMixin, RegistryMixinProperties } from '@dojo/widget-core/mixins/Registry';
 import { theme, ThemeableMixin, ThemeableProperties } from '@dojo/widget-core/mixins/Themeable';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
-import { HasColumns, HasItems } from './interfaces';
+import { HasColumns, HasItems, HasScrollTo } from './interfaces';
 import Row from './Row';
 
 import * as bodyClasses from './styles/body.m.css';
 
 export const BodyBase = ThemeableMixin(RegistryMixin(WidgetBase));
 
-export interface BodyProperties extends ThemeableProperties, HasColumns, HasItems, RegistryMixinProperties { }
+export interface BodyProperties extends ThemeableProperties, HasColumns, HasItems, HasScrollTo, RegistryMixinProperties { }
 
 @theme(bodyClasses)
 class Body extends BodyBase<BodyProperties> {

--- a/src/Body.ts
+++ b/src/Body.ts
@@ -5,14 +5,14 @@ import { DNode, PropertiesChangeEvent } from '@dojo/widget-core/interfaces';
 import { RegistryMixin, RegistryMixinProperties } from '@dojo/widget-core/mixins/Registry';
 import { theme, ThemeableMixin, ThemeableProperties } from '@dojo/widget-core/mixins/Themeable';
 import WidgetBase, { onPropertiesChanged } from '@dojo/widget-core/WidgetBase';
-import { HasBufferRows, HasColumns, HasItems, HasScrollTo, HasSize, HasSlice, HasSliceEvent, ItemProperties } from './interfaces';
+import { HasBufferRows, HasColumns, HasItems, HasScrollTo, HasScrollToEvent, HasSize, HasSlice, HasSliceEvent, ItemProperties } from './interfaces';
 import Row from './Row';
 
-import * as bodyClasses from './styles/body.m.css';
+import * as css from './styles/body.m.css';
 
 export const BodyBase = ThemeableMixin(RegistryMixin(WidgetBase));
 
-export interface BodyProperties extends ThemeableProperties, HasBufferRows, HasColumns, HasItems, HasScrollTo, HasSize, HasSlice, HasSliceEvent, RegistryMixinProperties {}
+export interface BodyProperties extends ThemeableProperties, HasBufferRows, HasColumns, HasItems, HasScrollTo, HasScrollToEvent, HasSize, HasSlice, HasSliceEvent, RegistryMixinProperties {}
 
 interface RenderedDetails {
 	add: boolean;
@@ -22,7 +22,7 @@ interface RenderedDetails {
 	height?: number;
 }
 
-@theme(bodyClasses)
+@theme(css)
 class Body extends BodyBase<BodyProperties> {
 	private _firstVisibleKey: string;
 	private _itemElementMap = new Map<string, RenderedDetails>();
@@ -556,7 +556,7 @@ class Body extends BodyBase<BodyProperties> {
 		}
 
 		return v('div', {
-			classes: this.classes(bodyClasses.scroller),
+			classes: this.classes(css.scroller),
 			key: 'scroller',
 			onscroll: this.onScroll
 		}, children);

--- a/src/Grid.ts
+++ b/src/Grid.ts
@@ -50,7 +50,7 @@ class Grid extends GridBase<GridProperties> {
 
 			this._subscription && this._subscription.unsubscribe();
 			this._subscription = dataProvider.observe().subscribe((data) => {
-				this._data = (data || {});
+				this._data = data;
 				this.invalidate();
 			});
 		}

--- a/src/Header.ts
+++ b/src/Header.ts
@@ -4,14 +4,14 @@ import { RegistryMixin, RegistryMixinProperties }  from '@dojo/widget-core/mixin
 import { ThemeableMixin, theme, ThemeableProperties } from '@dojo/widget-core/mixins/Themeable';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
 import HeaderCell from './HeaderCell';
-import { HasColumns, HasSliceEvent, HasSortDetails, HasSortEvent } from './interfaces';
+import { HasColumns, HasSortDetails, HasSortEvent } from './interfaces';
 
 import * as css from './styles/header.m.css';
 import * as tableCss from './styles/shared/table.m.css';
 
 export const HeaderBase = ThemeableMixin(RegistryMixin(WidgetBase));
 
-export interface HeaderProperties extends ThemeableProperties, HasColumns, HasSliceEvent, HasSortDetails, HasSortEvent, RegistryMixinProperties {}
+export interface HeaderProperties extends ThemeableProperties, HasColumns, HasSortDetails, HasSortEvent, RegistryMixinProperties {}
 
 @theme(tableCss)
 @theme(css)

--- a/src/Header.ts
+++ b/src/Header.ts
@@ -4,14 +4,14 @@ import { RegistryMixin, RegistryMixinProperties }  from '@dojo/widget-core/mixin
 import { ThemeableMixin, theme, ThemeableProperties } from '@dojo/widget-core/mixins/Themeable';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
 import HeaderCell from './HeaderCell';
-import { HasColumns, HasSortDetails, HasSortEvent } from './interfaces';
+import { HasColumns, HasSliceEvent, HasSortDetails, HasSortEvent } from './interfaces';
 
 import * as css from './styles/header.m.css';
 import * as tableCss from './styles/shared/table.m.css';
 
 export const HeaderBase = ThemeableMixin(RegistryMixin(WidgetBase));
 
-export interface HeaderProperties extends ThemeableProperties, HasColumns, HasSortDetails, HasSortEvent, RegistryMixinProperties {}
+export interface HeaderProperties extends ThemeableProperties, HasColumns, HasSliceEvent, HasSortDetails, HasSortEvent, RegistryMixinProperties {}
 
 @theme(tableCss)
 @theme(css)

--- a/src/bases/DataProviderBase.ts
+++ b/src/bases/DataProviderBase.ts
@@ -1,5 +1,5 @@
 import { Observable, Observer } from '@dojo/core/Observable';
-import { DataProperties, SortDetails } from '../interfaces';
+import { DataProperties, SliceDetails, SortDetails } from '../interfaces';
 
 /**
  * Used by subclasses to add properties
@@ -12,6 +12,7 @@ export interface DataProviderOptions {}
  * to make batched state changes to the data provider.
  */
 export interface DataProviderConfiguration {
+	slice?: SliceDetails;
 	sort?: SortDetails | SortDetails[];
 }
 
@@ -20,6 +21,7 @@ export interface DataProviderConfiguration {
  * to provide state to subclasses.
  */
 export interface DataProviderState {
+	slice?: SliceDetails;
 	sort?: SortDetails[];
 }
 
@@ -71,7 +73,11 @@ abstract class DataProviderBase<T = object, O extends DataProviderOptions = Data
 	 *
 	 * @param configuration - State changes to make
 	 */
-	configure({ sort }: C, updateData = true): void {
+	configure({ slice, sort }: C, updateData = true): void {
+		/* istanbul ignore else: slice is not a required argument */
+		if (slice) {
+			this.state.slice = slice;
+		}
 		/* istanbul ignore else: sort is not a required argument */
 		if (sort) {
 			this.state.sort = Array.isArray(sort) ? sort : [ sort ];
@@ -98,6 +104,18 @@ abstract class DataProviderBase<T = object, O extends DataProviderOptions = Data
 	 */
 	observe(): Observable<DataProperties<T>> {
 		return this._observable;
+	}
+
+	/**
+	 * Apply a slice to the data that would be returned
+	 * otherwise. Can also be assigned from
+	 * {@link DataProviderBase#configure}.
+	 *
+	 * @param slice - Where to slice from and how many items to include
+	 */
+	slice(slice: SliceDetails) {
+		this.state.slice = slice;
+		this.updateData();
 	}
 
 	/**

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -7,8 +7,20 @@ export interface Column<T> {
 
 export interface DataProperties<T> {
 	items: ItemProperties<T>[];
+	size: SizeDetails;
 	slice?: SliceDetails;
 	sort?: SortDetails[];
+}
+
+export interface HasBufferRows {
+	/**
+	 * @default 10
+	 */
+	bufferRows?: number;
+	/**
+	 * @default 5
+	 */
+	rowDrift?: number;
 }
 
 export interface HasColumn {
@@ -19,12 +31,20 @@ export interface HasColumns {
 	columns: Column<any>[];
 }
 
+export interface HasSize {
+	size: SizeDetails;
+}
+
 export interface HasSortDetail {
 	sortDetail?: SortDetails;
 }
 
 export interface HasSortDetails {
 	sortDetails: SortDetails[];
+}
+
+export interface HasSlice {
+	slice?: SliceDetails;
 }
 
 export interface HasSliceEvent {
@@ -55,6 +75,7 @@ export interface HasValue {
 
 export interface ItemProperties<T = any> {
 	id: string;
+	index: number;
 	data: T;
 }
 
@@ -64,11 +85,16 @@ export interface ScrollToDetails {
 }
 
 export interface ScrollToCompleteListener {
-	(index: number): void;
+	(scrollTo: ScrollToDetails): void;
 }
 
 export interface ScrollToRequestListener {
-	(index: number): void;
+	(scrollTo: ScrollToDetails): void;
+}
+
+export interface SizeDetails {
+	dataLength: number;
+	totalLength: number;
 }
 
 export interface SliceDetails {
@@ -77,7 +103,7 @@ export interface SliceDetails {
 }
 
 export interface SliceRequestListener {
-	onSliceRequest(sliceDetails: SliceDetails): void;
+	(sliceDetails: SliceDetails): void;
 }
 
 export type SortDirection = 'asc' | 'desc';

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -53,7 +53,7 @@ export interface HasValue {
 	value: string;
 }
 
-export interface ItemProperties<T> {
+export interface ItemProperties<T = any> {
 	id: string;
 	data: T;
 }

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -66,6 +66,9 @@ export interface HasItems {
 export interface HasScrollTo {
 	scrollTo?: ScrollToDetails;
 	onScrollToComplete?: ScrollToCompleteListener;
+}
+
+export interface HasScrollToEvent {
 	onScrollToRequest?: ScrollToRequestListener;
 }
 

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -28,7 +28,7 @@ export interface HasSortDetails {
 }
 
 export interface HasSliceEvent {
-	onSliceRequest(sliceDetails: SliceDetails): void;
+	onSliceRequest: SliceRequestListener;
 }
 
 export interface HasSortEvent {
@@ -43,6 +43,12 @@ export interface HasItems {
 	items: ItemProperties<any>[];
 }
 
+export interface HasScrollTo {
+	scrollTo?: ScrollToDetails;
+	onScrollToComplete?: ScrollToCompleteListener;
+	onScrollToRequest?: ScrollToRequestListener;
+}
+
 export interface HasValue {
 	value: string;
 }
@@ -52,9 +58,26 @@ export interface ItemProperties<T> {
 	data: T;
 }
 
+export interface ScrollToDetails {
+	index: number;
+	position?: 'top';
+}
+
+export interface ScrollToCompleteListener {
+	(index: number): void;
+}
+
+export interface ScrollToRequestListener {
+	(index: number): void;
+}
+
 export interface SliceDetails {
 	start: number;
 	count: number;
+}
+
+export interface SliceRequestListener {
+	onSliceRequest(sliceDetails: SliceDetails): void;
 }
 
 export type SortDirection = 'asc' | 'desc';

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -7,6 +7,7 @@ export interface Column<T> {
 
 export interface DataProperties<T> {
 	items: ItemProperties<T>[];
+	slice?: SliceDetails;
 	sort?: SortDetails[];
 }
 
@@ -26,8 +27,8 @@ export interface HasSortDetails {
 	sortDetails: SortDetails[];
 }
 
-export interface SortRequestListener {
-	(sortDetail: SortDetails): void;
+export interface HasSliceEvent {
+	onSliceRequest(sliceDetails: SliceDetails): void;
 }
 
 export interface HasSortEvent {
@@ -51,6 +52,11 @@ export interface ItemProperties<T> {
 	data: T;
 }
 
+export interface SliceDetails {
+	start: number;
+	count: number;
+}
+
 export type SortDirection = 'asc' | 'desc';
 
 export interface SortDetails {
@@ -59,4 +65,8 @@ export interface SortDetails {
 	 * @default 'asc'
 	 */
 	direction?: SortDirection;
+}
+
+export interface SortRequestListener {
+	(sortDetail: SortDetails): void;
 }

--- a/src/providers/ArrayDataProvider.ts
+++ b/src/providers/ArrayDataProvider.ts
@@ -6,12 +6,13 @@ export interface ArrayDataProviderOptions<T> extends DataProviderOptions {
 	data: T[];
 }
 
-function expand(items: any[], idProperty: string) {
+function expand(items: any[], idProperty: string, index = 0) {
 	const array: ItemProperties<any>[] = [];
 	for (const item of items) {
 		const id = String(item[idProperty]);
 		array.push({
 			id,
+			index: index++,
 			data: item
 		});
 	}
@@ -57,6 +58,10 @@ class ArrayDataProvider<T = object> extends DataProviderBase<T, ArrayDataProvide
 		}
 
 		this.data = {
+			size: {
+				dataLength: data.length,
+				totalLength: data.length
+			},
 			slice,
 			sort,
 			items: itemProperties

--- a/src/providers/ArrayDataProvider.ts
+++ b/src/providers/ArrayDataProvider.ts
@@ -26,13 +26,14 @@ class ArrayDataProvider<T = object> extends DataProviderBase<T, ArrayDataProvide
 				data
 			},
 			state: {
+				slice,
 				sort
 			}
 		} = this;
 
-		let items = data;
+		let items = [ ...data ];
 		if (sort && sort.length) {
-			items = [ ...items ].sort((a: any, b: any) => {
+			items = items.sort((a: any, b: any) => {
 				for (let field of sort) {
 					const aValue = a[field.columnId];
 					const bValue = b[field.columnId];
@@ -49,8 +50,14 @@ class ArrayDataProvider<T = object> extends DataProviderBase<T, ArrayDataProvide
 				return 0;
 			});
 		}
-		const itemProperties = expand(items, idProperty);
+
+		let itemProperties = expand(items, idProperty);
+		if (slice) {
+			itemProperties = itemProperties.slice(slice.start, (slice.start + slice.count));
+		}
+
 		this.data = {
+			slice,
 			sort,
 			items: itemProperties
 		};

--- a/src/styles/body.m.css
+++ b/src/styles/body.m.css
@@ -1,10 +1,9 @@
 .scroller {
     flex-grow: 1;
-    overflow-x: auto;
+    overflow-x: hidden;
     overflow-y: scroll;
     padding-bottom: 0px;
-}
-
-.content {
+    padding-right: 80px;
+    margin-right: -80px;
     position: relative;
 }

--- a/src/styles/body.m.css.d.ts
+++ b/src/styles/body.m.css.d.ts
@@ -1,2 +1,1 @@
 export const scroller: string;
-export const content: string;

--- a/src/styles/dgrid.css
+++ b/src/styles/dgrid.css
@@ -3,6 +3,7 @@
 @import 'shared/table.m.css';
 @import 'header.m.css';
 @import 'headerCell.m.css';
+@import 'body.m.css';
 @import 'row.m.css';
 @import 'cell.m.css';
 @import 'footer.m.css';

--- a/tests/unit/ArrayDataProvider.ts
+++ b/tests/unit/ArrayDataProvider.ts
@@ -17,20 +17,21 @@ registerSuite({
 				{ id: '4' }
 			]
 		});
-		let data: DataProperties<any> = { items: [] };
+		let data: DataProperties<any> = <any> {};
 		const subscription = dataProvider.observe().subscribe((updated) => {
 			data = updated;
 		});
 		dataProvider.sort({ columnId: 'id' });
+		dataProvider.slice({ start: 0, count: 4});
 
 		assert.deepEqual(data, {
+			slice: { start: 0, count: 4},
 			sort: [ { columnId: 'id', direction: 'asc' } ],
 			items: [
 				{ id: '1', data: { id: 1 } },
 				{ id: '2', data: { id: '2' } },
 				{ id: '3', data: { id: 3 } },
-				{ id: '4', data: { id: '4' } },
-				{ id: '5', data: { id: 5 } }
+				{ id: '4', data: { id: '4' } }
 			]
 		});
 
@@ -47,16 +48,16 @@ registerSuite({
 				{ id: 4 }
 			]
 		});
-		let data: DataProperties<any> = { items: [] };
+		let data: DataProperties<any> = <any> {};
 		const subscription = dataProvider.observe().subscribe((updated) => {
 			data = updated;
 		});
-		dataProvider.configure({ sort: { columnId: 'id', direction: 'asc' } });
+		dataProvider.configure({ slice: { start: 1, count: 4 }, sort: { columnId: 'id', direction: 'asc' } });
 
 		assert.deepEqual(data, {
+			slice: { start: 1, count: 4},
 			sort: [ { columnId: 'id', direction: 'asc' } ],
 			items: [
-				{ id: '1', data: { id: 1 } },
 				{ id: '2', data: { id: 2 } },
 				{ id: '3', data: { id: 3 } },
 				{ id: '4', data: { id: 4 } },
@@ -77,13 +78,14 @@ registerSuite({
 				{ id: 4 }
 			]
 		});
-		let data: DataProperties<any> = { items: [] };
+		let data: DataProperties<any> = <any> {};
 		const subscription = dataProvider.observe().subscribe((updated) => {
 			data = updated;
 		});
 		dataProvider.sort({ columnId: 'id', direction: 'asc' });
 
 		assert.deepEqual(data, {
+			slice: undefined,
 			sort: [ { columnId: 'id', direction: 'asc' } ],
 			items: [
 				{ id: '1', data: { id: 1 } },
@@ -109,12 +111,13 @@ registerSuite({
 		}, {
 			sort: { columnId: 'id', direction: 'asc' }
 		});
-		let data: DataProperties<any> = { items: [] };
+		let data: DataProperties<any> = <any> {};
 		const subscription = dataProvider.observe().subscribe((updated) => {
 			data = updated;
 		});
 		dataProvider.notify();
 		assert.deepEqual(data, {
+			slice: undefined,
 			sort: [ { columnId: 'id', direction: 'asc' } ],
 			items: [
 				{ id: '1', data: { id: 1 } },
@@ -138,7 +141,7 @@ registerSuite({
 				{ id: 2, letter: 'a' }
 			]
 		});
-		let data: DataProperties<any> = { items: [] };
+		let data: DataProperties<any> = <any> {};
 		const subscription = dataProvider.observe().subscribe((updated) => {
 			data = updated;
 		});
@@ -152,6 +155,7 @@ registerSuite({
 		}
 
 		assert.deepEqual(data, {
+			slice: undefined,
 			sort: [ { columnId: 'letter', direction: 'desc' } ],
 			items: [
 				{ data: { letter: 'c' } },
@@ -175,13 +179,14 @@ registerSuite({
 				{ id: 2, letter: 'a' }
 			]
 		});
-		let data: DataProperties<any> = { items: [] };
+		let data: DataProperties<any> = <any> {};
 		const subscription = dataProvider.observe().subscribe((updated) => {
 			data = updated;
 		});
 		dataProvider.sort([ { columnId: 'letter', direction: 'desc' }, { columnId: 'id', direction: 'asc' } ]);
 
 		assert.deepEqual(data, {
+			slice: undefined,
 			sort: [ { columnId: 'letter', direction: 'desc' }, { columnId: 'id', direction: 'asc' } ],
 			items: [
 				{ id: '5', data: { id: 5, letter: 'c' } },
@@ -208,12 +213,13 @@ registerSuite({
 		dataProvider.configure({
 			sort: [ { columnId: 'letter', direction: 'desc' }, { columnId: 'id', direction: 'asc' } ]
 		});
-		let data: DataProperties<any> = { items: [] };
+		let data: DataProperties<any> = <any> {};
 		const subscription = dataProvider.observe().subscribe((updated) => {
 			data = updated;
 		});
 
 		assert.deepEqual(data, {
+			slice: undefined,
 			sort: [ { columnId: 'letter', direction: 'desc' }, { columnId: 'id', direction: 'asc' } ],
 			items: [
 				{ id: '5', data: { id: 5, letter: 'c' } },
@@ -240,12 +246,13 @@ registerSuite({
 			sort: [ { columnId: 'letter', direction: 'desc' }, { columnId: 'id', direction: 'asc' } ]
 		});
 		dataProvider.notify(); // build data before adding an observer
-		let data: DataProperties<any> = { items: [] };
+		let data: DataProperties<any> = <any> {};
 		const subscription = dataProvider.observe().subscribe((updated) => {
 			data = updated;
 		});
 
 		assert.deepEqual(data, {
+			slice: undefined,
 			sort: [ { columnId: 'letter', direction: 'desc' }, { columnId: 'id', direction: 'asc' } ],
 			items: [
 				{ id: '5', data: { id: 5, letter: 'c' } },

--- a/tests/unit/ArrayDataProvider.ts
+++ b/tests/unit/ArrayDataProvider.ts
@@ -25,13 +25,17 @@ registerSuite({
 		dataProvider.slice({ start: 0, count: 4});
 
 		assert.deepEqual(data, {
+			size: {
+				dataLength: 5,
+				totalLength: 5
+			},
 			slice: { start: 0, count: 4},
 			sort: [ { columnId: 'id', direction: 'asc' } ],
 			items: [
-				{ id: '1', data: { id: 1 } },
-				{ id: '2', data: { id: '2' } },
-				{ id: '3', data: { id: 3 } },
-				{ id: '4', data: { id: '4' } }
+				{ id: '1', index: 0, data: { id: 1 } },
+				{ id: '2', index: 1, data: { id: '2' } },
+				{ id: '3', index: 2, data: { id: 3 } },
+				{ id: '4', index: 3, data: { id: '4' } }
 			]
 		});
 
@@ -55,13 +59,17 @@ registerSuite({
 		dataProvider.configure({ slice: { start: 1, count: 4 }, sort: { columnId: 'id', direction: 'asc' } });
 
 		assert.deepEqual(data, {
+			size: {
+				dataLength: 5,
+				totalLength: 5
+			},
 			slice: { start: 1, count: 4},
 			sort: [ { columnId: 'id', direction: 'asc' } ],
 			items: [
-				{ id: '2', data: { id: 2 } },
-				{ id: '3', data: { id: 3 } },
-				{ id: '4', data: { id: 4 } },
-				{ id: '5', data: { id: 5 } }
+				{ id: '2', index: 1, data: { id: 2 } },
+				{ id: '3', index: 2, data: { id: 3 } },
+				{ id: '4', index: 3, data: { id: 4 } },
+				{ id: '5', index: 4, data: { id: 5 } }
 			]
 		});
 
@@ -85,14 +93,18 @@ registerSuite({
 		dataProvider.sort({ columnId: 'id', direction: 'asc' });
 
 		assert.deepEqual(data, {
+			size: {
+				dataLength: 5,
+				totalLength: 5
+			},
 			slice: undefined,
 			sort: [ { columnId: 'id', direction: 'asc' } ],
 			items: [
-				{ id: '1', data: { id: 1 } },
-				{ id: '2', data: { id: 2 } },
-				{ id: '3', data: { id: 3 } },
-				{ id: '4', data: { id: 4 } },
-				{ id: '5', data: { id: 5 } }
+				{ id: '1', index: 0, data: { id: 1 } },
+				{ id: '2', index: 1, data: { id: 2 } },
+				{ id: '3', index: 2, data: { id: 3 } },
+				{ id: '4', index: 3, data: { id: 4 } },
+				{ id: '5', index: 4, data: { id: 5 } }
 			]
 		});
 
@@ -117,14 +129,18 @@ registerSuite({
 		});
 		dataProvider.notify();
 		assert.deepEqual(data, {
+			size: {
+				dataLength: 5,
+				totalLength: 5
+			},
 			slice: undefined,
 			sort: [ { columnId: 'id', direction: 'asc' } ],
 			items: [
-				{ id: '1', data: { id: 1 } },
-				{ id: '2', data: { id: 2 } },
-				{ id: '3', data: { id: 3 } },
-				{ id: '4', data: { id: 4 } },
-				{ id: '5', data: { id: 5 } }
+				{ id: '1', index: 0, data: { id: 1 } },
+				{ id: '2', index: 1, data: { id: 2 } },
+				{ id: '3', index: 2, data: { id: 3 } },
+				{ id: '4', index: 3, data: { id: 4 } },
+				{ id: '5', index: 4, data: { id: 5 } }
 			]
 		});
 
@@ -155,14 +171,18 @@ registerSuite({
 		}
 
 		assert.deepEqual(data, {
+			size: {
+				dataLength: 5,
+				totalLength: 5
+			},
 			slice: undefined,
 			sort: [ { columnId: 'letter', direction: 'desc' } ],
 			items: [
-				{ data: { letter: 'c' } },
-				{ data: { letter: 'b' } },
-				{ data: { letter: 'b' } },
-				{ data: { letter: 'a' } },
-				{ data: { letter: 'a' } }
+				{ index: 0, data: { letter: 'c' } },
+				{ index: 1, data: { letter: 'b' } },
+				{ index: 2, data: { letter: 'b' } },
+				{ index: 3, data: { letter: 'a' } },
+				{ index: 4, data: { letter: 'a' } }
 			]
 		});
 
@@ -186,14 +206,18 @@ registerSuite({
 		dataProvider.sort([ { columnId: 'letter', direction: 'desc' }, { columnId: 'id', direction: 'asc' } ]);
 
 		assert.deepEqual(data, {
+			size: {
+				dataLength: 5,
+				totalLength: 5
+			},
 			slice: undefined,
 			sort: [ { columnId: 'letter', direction: 'desc' }, { columnId: 'id', direction: 'asc' } ],
 			items: [
-				{ id: '5', data: { id: 5, letter: 'c' } },
-				{ id: '3', data: { id: 3, letter: 'b' } },
-				{ id: '4', data: { id: 4, letter: 'b' } },
-				{ id: '1', data: { id: 1, letter: 'a' } },
-				{ id: '2', data: { id: 2, letter: 'a' } }
+				{ id: '5', index: 0, data: { id: 5, letter: 'c' } },
+				{ id: '3', index: 1, data: { id: 3, letter: 'b' } },
+				{ id: '4', index: 2, data: { id: 4, letter: 'b' } },
+				{ id: '1', index: 3, data: { id: 1, letter: 'a' } },
+				{ id: '2', index: 4, data: { id: 2, letter: 'a' } }
 			]
 		});
 
@@ -219,14 +243,18 @@ registerSuite({
 		});
 
 		assert.deepEqual(data, {
+			size: {
+				dataLength: 5,
+				totalLength: 5
+			},
 			slice: undefined,
 			sort: [ { columnId: 'letter', direction: 'desc' }, { columnId: 'id', direction: 'asc' } ],
 			items: [
-				{ id: '5', data: { id: 5, letter: 'c' } },
-				{ id: '3', data: { id: 3, letter: 'b' } },
-				{ id: '4', data: { id: 4, letter: 'b' } },
-				{ id: '1', data: { id: 1, letter: 'a' } },
-				{ id: '2', data: { id: 2, letter: 'a' } }
+				{ id: '5', index: 0, data: { id: 5, letter: 'c' } },
+				{ id: '3', index: 1, data: { id: 3, letter: 'b' } },
+				{ id: '4', index: 2, data: { id: 4, letter: 'b' } },
+				{ id: '1', index: 3, data: { id: 1, letter: 'a' } },
+				{ id: '2', index: 4, data: { id: 2, letter: 'a' } }
 			]
 		});
 
@@ -252,14 +280,18 @@ registerSuite({
 		});
 
 		assert.deepEqual(data, {
+			size: {
+				dataLength: 5,
+				totalLength: 5
+			},
 			slice: undefined,
 			sort: [ { columnId: 'letter', direction: 'desc' }, { columnId: 'id', direction: 'asc' } ],
 			items: [
-				{ id: '5', data: { id: 5, letter: 'c' } },
-				{ id: '3', data: { id: 3, letter: 'b' } },
-				{ id: '4', data: { id: 4, letter: 'b' } },
-				{ id: '1', data: { id: 1, letter: 'a' } },
-				{ id: '2', data: { id: 2, letter: 'a' } }
+				{ id: '5', index: 0, data: { id: 5, letter: 'c' } },
+				{ id: '3', index: 1, data: { id: 3, letter: 'b' } },
+				{ id: '4', index: 2, data: { id: 4, letter: 'b' } },
+				{ id: '1', index: 3, data: { id: 1, letter: 'a' } },
+				{ id: '2', index: 4, data: { id: 2, letter: 'a' } }
 			]
 		});
 

--- a/tests/unit/Body.ts
+++ b/tests/unit/Body.ts
@@ -28,6 +28,7 @@ registerSuite({
 		];
 		const item: ItemProperties<any> = {
 			id: '1',
+			index: 0,
 			data: {
 				id: 1,
 				foo: 'foo',
@@ -37,14 +38,25 @@ registerSuite({
 		widget.setProperties({
 			columns,
 			items: [ item ],
-			registry
+			onSliceRequest: widget.listener,
+			registry,
+			size: {
+				dataLength: 2,
+				totalLength: 2
+			}
 		});
 
 		widget.expectRender(v('div', {
-			classes: widget.classes(css.scroller)
+			afterCreate: widget.listener,
+			afterUpdate: widget.listener,
+			classes: widget.classes(css.scroller),
+			key: 'scroller',
+			onscroll: widget.listener
 		}, [
 			v('div', {
-				classes: widget.classes(css.content)
+				afterCreate: widget.listener,
+				afterUpdate: widget.listener,
+				key: '1'
 			}, [
 				w<Row>('row', {
 					columns,

--- a/tests/unit/Cell.ts
+++ b/tests/unit/Cell.ts
@@ -13,6 +13,7 @@ const column: Column<any> = {
 };
 const item: ItemProperties<any> = {
 	id: 'item',
+	index: 0,
 	data: {}
 };
 let widget: Harness<CellProperties, typeof Cell>;

--- a/tests/unit/Grid.ts
+++ b/tests/unit/Grid.ts
@@ -32,10 +32,12 @@ const columns: Column<any>[] = [
 const items = [
 	{
 		id: 1,
+		index: 0,
 		name: 'One'
 	},
 	{
 		id: 2,
+		index: 1,
 		name: 'Two'
 	}
 ];
@@ -43,10 +45,12 @@ const items = [
 const itemProperties: ItemProperties<any>[] = [
 	{
 		id: '1',
+		index: 0,
 		data: items[0]
 	},
 	{
 		id: '2',
+		index: 1,
 		data: items[1]
 	}
 ];
@@ -65,10 +69,12 @@ const items2 = [
 const itemProperties2: ItemProperties<any>[] = [
 	{
 		id: '3',
+		index: 0,
 		data: items2[0]
 	},
 	{
 		id: '4',
+		index: 1,
 		data: items2[1]
 	}
 ];
@@ -87,12 +93,14 @@ registerSuite({
 	},
 
 	'dgrid'() {
-		widget.setProperties({
+		const properties: GridProperties = {
 			dataProvider: new ArrayDataProvider({
 				data: items
 			}),
 			columns
-		});
+		};
+		properties.dataProvider.notify();
+		widget.setProperties(properties);
 
 		widget.expectRender(v('div', {
 			classes: widget.classes(css.grid),
@@ -106,9 +114,20 @@ registerSuite({
 				onSortRequest: widget.listener
 			}),
 			w<Body>('body', {
+				bufferRows: undefined,
 				columns,
 				items: itemProperties,
+				onScrollToComplete: widget.listener,
+				onScrollToRequest: widget.listener,
+				onSliceRequest: widget.listener,
 				registry: compareRegistryProperty,
+				rowDrift: undefined,
+				scrollTo: undefined,
+				size: {
+					dataLength: 2,
+					totalLength: 2
+				},
+				slice: undefined,
 				theme: undefined
 			})
 		]));
@@ -133,9 +152,20 @@ registerSuite({
 				onSortRequest: widget.listener
 			}),
 			w<Body>('body', {
+				bufferRows: undefined,
 				columns,
 				items: [],
+				onScrollToComplete: widget.listener,
+				onScrollToRequest: widget.listener,
+				onSliceRequest: widget.listener,
 				registry: compareRegistryProperty,
+				rowDrift: undefined,
+				scrollTo: undefined,
+				size: {
+					dataLength: 0,
+					totalLength: 0
+				},
+				slice: undefined,
 				theme: undefined
 			})
 		]));
@@ -148,6 +178,7 @@ registerSuite({
 			}),
 			columns
 		};
+		properties.dataProvider.notify();
 
 		widget.setProperties(properties);
 
@@ -163,9 +194,20 @@ registerSuite({
 				onSortRequest: widget.listener
 			}),
 			w<Body>('body', {
+				bufferRows: undefined,
 				columns,
 				items: itemProperties,
+				onScrollToComplete: widget.listener,
+				onScrollToRequest: widget.listener,
+				onSliceRequest: widget.listener,
 				registry: compareRegistryProperty,
+				rowDrift: undefined,
+				scrollTo: undefined,
+				size: {
+					dataLength: 2,
+					totalLength: 2
+				},
+				slice: undefined,
 				theme: undefined
 			})
 		]);
@@ -184,7 +226,7 @@ registerSuite({
 		});
 
 		assignChildProperties(expected, 1, {
-			items: [ itemProperties[1], itemProperties[0] ]
+			items: [ { ...itemProperties[1], index: 0 }, { ...itemProperties[0], index: 1 } ]
 		});
 
 		widget.expectRender(expected);
@@ -197,6 +239,7 @@ registerSuite({
 			}),
 			columns
 		};
+		properties.dataProvider.notify();
 
 		widget.setProperties(properties);
 
@@ -212,9 +255,20 @@ registerSuite({
 				onSortRequest: widget.listener
 			}),
 			w<Body>('body', {
+				bufferRows: undefined,
 				columns,
 				items: itemProperties,
+				onScrollToComplete: widget.listener,
+				onScrollToRequest: widget.listener,
+				onSliceRequest: widget.listener,
 				registry: compareRegistryProperty,
+				rowDrift: undefined,
+				scrollTo: undefined,
+				size: {
+					dataLength: 2,
+					totalLength: 2
+				},
+				slice: undefined,
 				theme: undefined
 			})
 		]);
@@ -227,6 +281,7 @@ registerSuite({
 				data: items2
 			})
 		};
+		properties.dataProvider.notify();
 
 		assignChildProperties(expected, 1, {
 			items: itemProperties2

--- a/tests/unit/Grid.ts
+++ b/tests/unit/Grid.ts
@@ -94,10 +94,14 @@ registerSuite({
 
 	'dgrid'() {
 		const properties: GridProperties = {
+			columns,
 			dataProvider: new ArrayDataProvider({
 				data: items
 			}),
-			columns
+			scrollTo: {
+				index: 0,
+				position: 'top'
+			}
 		};
 		properties.dataProvider.notify();
 		widget.setProperties(properties);
@@ -122,7 +126,10 @@ registerSuite({
 				onSliceRequest: widget.listener,
 				registry: compareRegistryProperty,
 				rowDrift: undefined,
-				scrollTo: undefined,
+				scrollTo: {
+					index: 0,
+					position: 'top'
+				},
 				size: {
 					dataLength: 2,
 					totalLength: 2

--- a/tests/unit/Row.ts
+++ b/tests/unit/Row.ts
@@ -25,6 +25,7 @@ registerSuite({
 	'Simple columns'() {
 		const item: ItemProperties<any> = {
 			id: '1',
+			index: 0,
 			data: {
 				id: 1,
 				foo: 'foo',


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #21 

This introduces the slice API to data providers to request the data only contain a subsection of the currently available data the provider would otherwise return (including sorts etc.)

The grid body makes a slice request to the data provider that will contain enough data to fill the content area as well as buffer rows above and below it.

As rows are added and removed from the grid, their heights are factored into the scroll position of the scrollable area to ensure that as the size of the scrollable content changes, the scroll position remains at the same position within the visible content.

It adds a large margin before and after the content area so that rapid scrolling won't "hit an edge".

If scrolling is done so rapidly that the user ends up outside the buffer rows, the grid body estimates how far it has been scrolled beyond the buffer rows, makes a slice for that data, and scrolls to the estimated row.

Users can also define what index to scroll the data to through a grid property.