### PR TITLE
Upgrading to TS 2.4 (and latest widget-core)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "grunt-dojo2": "latest",
     "intern": "^3.4.1",
     "sinon": "^1.17.6",
-    "typescript": "~2.3.2"
+    "typescript": "~2.4.2"
   }
 }

--- a/src/Grid.ts
+++ b/src/Grid.ts
@@ -4,7 +4,7 @@ import { DNode, PropertyChangeRecord } from '@dojo/widget-core/interfaces';
 import { RegistryMixin }  from '@dojo/widget-core/mixins/Registry';
 import { theme, ThemeableMixin, ThemeableProperties } from '@dojo/widget-core/mixins/Themeable';
 import WidgetBase, { diffProperty } from '@dojo/widget-core/WidgetBase';
-import { auto } from '@dojo/widget-core/diff';
+import { reference } from '@dojo/widget-core/diff';
 import DataProviderBase from './bases/DataProviderBase';
 import Body from './Body';
 import ColumnHeaders from './ColumnHeaders';
@@ -44,7 +44,7 @@ class Grid extends GridBase<GridProperties> {
 		this.getRegistries().add(gridRegistry);
 	}
 
-	@diffProperty('dataProvider', auto)
+	@diffProperty('dataProvider', reference)
 	protected diffPropertyDataProvider({ dataProvider: previousDataProvider }: GridProperties, { dataProvider }: GridProperties) {
 		this._sortRequestListener = dataProvider.sort.bind(dataProvider);
 

--- a/src/Grid.ts
+++ b/src/Grid.ts
@@ -4,6 +4,7 @@ import { DNode, PropertyChangeRecord } from '@dojo/widget-core/interfaces';
 import { RegistryMixin }  from '@dojo/widget-core/mixins/Registry';
 import { theme, ThemeableMixin, ThemeableProperties } from '@dojo/widget-core/mixins/Themeable';
 import WidgetBase, { diffProperty } from '@dojo/widget-core/WidgetBase';
+import { auto } from '@dojo/widget-core/diff';
 import DataProviderBase from './bases/DataProviderBase';
 import Body from './Body';
 import ColumnHeaders from './ColumnHeaders';
@@ -40,28 +41,20 @@ class Grid extends GridBase<GridProperties> {
 	constructor() {
 		super();
 
-		this.registries.add(gridRegistry);
+		this.getRegistries().add(gridRegistry);
 	}
 
-	@diffProperty('dataProvider')
-	protected diffPropertyDataProvider(previousDataProvider: DataProviderBase, dataProvider: DataProviderBase): PropertyChangeRecord {
-		const changed = (previousDataProvider !== dataProvider);
-		if (changed) {
-			this._sortRequestListener = dataProvider.sort.bind(dataProvider);
+	@diffProperty('dataProvider', auto)
+	protected diffPropertyDataProvider({ dataProvider: previousDataProvider }: GridProperties, { dataProvider }: GridProperties) {
+		this._sortRequestListener = dataProvider.sort.bind(dataProvider);
 
-			this._subscription && this._subscription.unsubscribe();
-			this._subscription = dataProvider.observe().subscribe((data) => {
-				this._data = (data || {});
-				this.invalidate();
-			});
-			// TODO: Remove notify when on demand scrolling (https://github.com/dojo/dgrid/issues/21 Initialization) is added
-			dataProvider.notify();
-		}
-
-		return {
-			changed,
-			value: dataProvider
-		};
+		this._subscription && this._subscription.unsubscribe();
+		this._subscription = dataProvider.observe().subscribe((data) => {
+			this._data = (data || {});
+			this.invalidate();
+		});
+		// TODO: Remove notify when on demand scrolling (https://github.com/dojo/dgrid/issues/21 Initialization) is added
+		dataProvider.notify();
 	}
 
 	protected inflateHeaderTypes(nodes: (HeaderType | DNode)[]): DNode[] {

--- a/src/GridRegistry.ts
+++ b/src/GridRegistry.ts
@@ -1,29 +1,16 @@
-import { WidgetBaseConstructor } from '@dojo/widget-core/interfaces';
-import WidgetRegistry from '@dojo/widget-core/WidgetRegistry';
-import Body, { BodyProperties } from './Body';
-import Cell, { CellProperties } from './Cell';
-import ColumnHeaderCell, { ColumnHeaderCellProperties } from './ColumnHeaderCell';
-import ColumnHeaders, { ColumnHeadersProperties } from './ColumnHeaders';
-import Footer, { FooterProperties } from './Footer';
-import Header, { HeaderProperties } from './Header';
-import PageLink, { PageLinkProperties } from './pagination/PageLink';
-import Pagination, { PaginationProperties } from './Pagination';
-import Row, { RowProperties } from './Row';
+import { Constructor, RegistryLabel, WidgetBaseInterface } from '@dojo/widget-core/interfaces';
+import WidgetRegistry, { WidgetRegistryItem } from '@dojo/widget-core/WidgetRegistry';
+import Body from './Body';
+import Cell from './Cell';
+import ColumnHeaderCell from './ColumnHeaderCell';
+import ColumnHeaders from './ColumnHeaders';
+import Footer from './Footer';
+import Header from './Header';
+import Pagination from './Pagination';
+import PageLink from './pagination/PageLink';
+import Row from './Row';
 
-export interface GridRegistered {
-	[key: string]: WidgetBaseConstructor;
-	body: WidgetBaseConstructor<BodyProperties>;
-	cell: WidgetBaseConstructor<CellProperties>;
-	'column-header-cell': WidgetBaseConstructor<ColumnHeaderCellProperties>;
-	'column-headers': WidgetBaseConstructor<ColumnHeadersProperties>;
-	footer: WidgetBaseConstructor<FooterProperties>;
-	header: WidgetBaseConstructor<HeaderProperties>;
-	'page-link': WidgetBaseConstructor<PageLinkProperties>;
-	pagination: WidgetBaseConstructor<PaginationProperties>;
-	row: WidgetBaseConstructor<RowProperties>;
-}
-
-export default class GridRegistry<T extends GridRegistered = GridRegistered> extends WidgetRegistry {
+export default class GridRegistry extends WidgetRegistry {
 	private _overrides: WidgetRegistry = new WidgetRegistry();
 
 	constructor() {
@@ -40,15 +27,15 @@ export default class GridRegistry<T extends GridRegistered = GridRegistered> ext
 		super.define('row', Row);
 	}
 
-	define<K extends keyof T>(widgetLabel: K, registryItem: T[K]): void {
+	define(widgetLabel: RegistryLabel, registryItem: WidgetRegistryItem): void {
 		this._overrides.define(widgetLabel, registryItem);
 	}
 
-	get<K extends keyof T>(widgetLabel: K): T[K] {
-		return <WidgetBaseConstructor> this._overrides.get(widgetLabel) || super.get(widgetLabel);
+	get<T extends WidgetBaseInterface = WidgetBaseInterface>(widgetLabel: RegistryLabel): Constructor<T> | null {
+		return this._overrides.get(widgetLabel) || super.get(widgetLabel);
 	}
 
-	has<K extends keyof T>(widgetLabel: K): boolean {
+	has(widgetLabel: RegistryLabel): boolean {
 		return this._overrides.has(widgetLabel) || super.has(widgetLabel);
 	}
 }

--- a/tests/unit/ColumnHeaderCell.ts
+++ b/tests/unit/ColumnHeaderCell.ts
@@ -206,7 +206,7 @@ registerSuite({
 			classes: widget.classes(cellCss.cell, css.columnHeaderCell, css.sortable)
 		});
 
-		properties.sortDetail = { ...properties.sortDetail, direction: 'desc' };
+		properties.sortDetail = { ...(properties.sortDetail as SortDetails), direction: 'desc' };
 		widget.setProperties(properties);
 
 		widget.expectRender(expected);

--- a/tests/unit/GridRegistry.ts
+++ b/tests/unit/GridRegistry.ts
@@ -8,7 +8,7 @@ import Cell from '../../src/Cell';
 import ColumnHeaderCell from '../../src/ColumnHeaderCell';
 import ColumnHeaders, { ColumnHeadersProperties } from '../../src/ColumnHeaders';
 import Footer from '../../src/Footer';
-import GridRegistry, { GridRegistered, gridRegistry } from '../../src/GridRegistry';
+import GridRegistry, { gridRegistry } from '../../src/GridRegistry';
 import Header from '../../src/Header';
 import Row from '../../src/Row';
 
@@ -28,11 +28,7 @@ registerSuite({
 	'Additional type'() {
 		class Header2 extends WidgetBase<ColumnHeadersProperties> {}
 
-		interface MoreRegistered extends GridRegistered {
-			header: typeof Header2;
-		}
-
-		const gridRegistry2 = new GridRegistry<MoreRegistered>();
+		const gridRegistry2 = new GridRegistry();
 		gridRegistry2.define('column-headers', Header2);
 		assert.equal(gridRegistry2.get('column-headers'), Header2);
 	}

--- a/tests/unit/Pagination.ts
+++ b/tests/unit/Pagination.ts
@@ -145,8 +145,6 @@ registerSuite({
 							onPageRequest: widget.listener
 						}),
 						v('span', {
-							afterCreate: widget.listener,
-							afterUpdate: widget.listener,
 							key: 'skip1',
 							classes: pageSkipClass
 						}, [ '...' ]),
@@ -177,8 +175,6 @@ registerSuite({
 							onPageRequest: widget.listener
 						}),
 						v('span', {
-							afterCreate: widget.listener,
-							afterUpdate: widget.listener,
 							key: 'skip2',
 							classes: pageSkipClass
 						}, [ '...' ]),


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Upgrading to TS 2.4 and latest widget-core changes. One big difference here is that `WidgetRegistry` now has a generic getter, so we no longer need the type magic that was provided by `GridRegistry`.

```typescript
// old, worked only for a subset of widget types
const Body = registry.get('body');

// new, works for all widget types
const Body = registry.get<Body>('body');
```

Resolves #44
