### PR TITLE
Updating Gruntfile to exclude examples folder on dist, issue #148

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,12 @@ module.exports = function (grunt) {
                 src: 'examples/**/*.{html,css,json,xml,js,txt}',
                 dest: '<%= devDirectory %>'
             }
-        }
+        },
+		ts: {
+			dist: {
+				exclude: ['tests/**/*.ts', 'examples/**/*.ts']
+			}
+		}
     });
 
     grunt.registerTask('dev', grunt.config.get('devTasks').concat([

--- a/src/Body.ts
+++ b/src/Body.ts
@@ -1,4 +1,5 @@
 import { v, w } from '@dojo/widget-core/d';
+import {DNode} from '@dojo/widget-core/interfaces';
 import { RegistryMixin, RegistryMixinProperties } from '@dojo/widget-core/mixins/Registry';
 import { theme, ThemeableMixin, ThemeableProperties } from '@dojo/widget-core/mixins/Themeable';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
@@ -13,7 +14,7 @@ export interface BodyProperties extends ThemeableProperties, HasColumns, HasItem
 
 @theme(bodyClasses)
 class Body extends BodyBase<BodyProperties> {
-	render() {
+	render(): DNode {
 		const {
 			columns,
 			items,


### PR DESCRIPTION
The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

I went with @agubler 's suggestion and just overrode the `Gruntfile`. The approach makes sense since no other packages have examples like this. This creates a `dist` folder that looks like the other packages (contents of `src/` are in `dist/umd/`).

There is another change included here to get the project to build with `grunt dist`.

Resolves https://github.com/dojo/grunt-dojo2/issues/148
